### PR TITLE
Convert to BusIO

### DIFF
--- a/Adafruit_MCP3008.cpp
+++ b/Adafruit_MCP3008.cpp
@@ -38,17 +38,10 @@
  *    @return true if process is successful
  */
 bool Adafruit_MCP3008::begin(uint8_t cs, SPIClass *theSPI) {
-  hwSPI = true;
-
-  this->cs = cs;
-
-  pinMode(this->cs, OUTPUT);
-  digitalWrite(this->cs, HIGH);
-  _spi = theSPI;
-  _spi->begin();
-  /* SPI.begin(); */
-
-  return true;
+  _cs = cs;
+  spi_dev = new Adafruit_SPIDevice(cs, MCP3008_SPI_FREQ, MCP3008_SPI_ORDER,
+                                   MCP3008_SPI_MODE, theSPI);
+  return spi_dev->begin();
 }
 
 /*!
@@ -65,23 +58,9 @@ bool Adafruit_MCP3008::begin(uint8_t cs, SPIClass *theSPI) {
  */
 bool Adafruit_MCP3008::begin(uint8_t sck, uint8_t mosi, uint8_t miso,
                              uint8_t cs) {
-  hwSPI = false;
-
-  this->sck = sck;
-  this->mosi = mosi;
-  this->miso = miso;
-  this->cs = cs;
-
-  pinMode(this->sck, OUTPUT);
-  pinMode(this->mosi, OUTPUT);
-  pinMode(this->miso, INPUT);
-  pinMode(this->cs, OUTPUT);
-
-  digitalWrite(this->sck, LOW);
-  digitalWrite(this->mosi, LOW);
-  digitalWrite(this->cs, HIGH);
-
-  return true;
+  _cs = cs;
+  spi_dev = new Adafruit_SPIDevice(cs, sck, miso, mosi, MCP3008_SPI_FREQ, MCP3008_SPI_ORDER, MCP3008_SPI_MODE);
+  return spi_dev->begin();
 }
 
 /*!
@@ -117,53 +96,13 @@ int Adafruit_MCP3008::readADCDifference(uint8_t differential) {
 
 // SPI transfer for ADC read
 int Adafruit_MCP3008::SPIxADC(uint8_t channel, bool differential) {
-  byte command, sgldiff;
-
-  if (differential) {
-    sgldiff = 0;
-  } else {
-    sgldiff = 1;
-  }
-
-  command = ((0x01 << 7) |             // start bit
-             (sgldiff << 6) |          // single or differential
-             ((channel & 0x07) << 3)); // channel number
-
-  if (hwSPI) {
-    byte b0, b1, b2;
-
-    _spi->beginTransaction(
-        SPISettings(MCP3008_SPI_MAX, MCP3008_SPI_ORDER, MCP3008_SPI_MODE));
-    digitalWrite(cs, LOW);
-
-    b0 = _spi->transfer(command);
-    b1 = _spi->transfer(0x00);
-    b2 = _spi->transfer(0x00);
-
-    digitalWrite(cs, HIGH);
-    _spi->endTransaction();
-
-    return 0x3FF & ((b0 & 0x01) << 9 | (b1 & 0xFF) << 1 | (b2 & 0x80) >> 7);
-
-  } else {
-
-    uint16_t outBuffer, inBuffer = 0;
-
-    digitalWrite(cs, LOW);
-
-    // 5 command bits + 1 null bit + 10 data bits = 16 bits
-    outBuffer = command << 8;
-    for (int c = 0; c < 16; c++) {
-      digitalWrite(mosi, (outBuffer >> (15 - c)) & 0x01);
-      digitalWrite(sck, HIGH);
-      digitalWrite(sck, LOW);
-      inBuffer <<= 1;
-      if (digitalRead(miso))
-        inBuffer |= 0x01;
-    }
-
-    digitalWrite(cs, HIGH);
-
-    return inBuffer & 0x3FF;
-  }
+  // see datasheet sec 6.1
+  buffer[0] = 0x01;
+  buffer[1] = ((differential ? 0 : 1) << 7) | (channel << 4);
+  spi_dev->beginTransaction();
+  digitalWrite(_cs, LOW);
+  spi_dev->transfer(buffer, 3);
+  digitalWrite(_cs, HIGH);
+  spi_dev->endTransaction();
+  return (((uint16_t)buffer[1] & 0x07) << 8) | buffer[2];
 }

--- a/Adafruit_MCP3008.cpp
+++ b/Adafruit_MCP3008.cpp
@@ -59,7 +59,8 @@ bool Adafruit_MCP3008::begin(uint8_t cs, SPIClass *theSPI) {
 bool Adafruit_MCP3008::begin(uint8_t sck, uint8_t mosi, uint8_t miso,
                              uint8_t cs) {
   _cs = cs;
-  spi_dev = new Adafruit_SPIDevice(cs, sck, miso, mosi, MCP3008_SPI_FREQ, MCP3008_SPI_ORDER, MCP3008_SPI_MODE);
+  spi_dev = new Adafruit_SPIDevice(cs, sck, miso, mosi, MCP3008_SPI_FREQ,
+                                   MCP3008_SPI_ORDER, MCP3008_SPI_MODE);
   return spi_dev->begin();
 }
 
@@ -104,5 +105,5 @@ int Adafruit_MCP3008::SPIxADC(uint8_t channel, bool differential) {
   spi_dev->transfer(buffer, 3);
   digitalWrite(_cs, HIGH);
   spi_dev->endTransaction();
-  return (((uint16_t)buffer[1] & 0x07) << 8) | buffer[2];
+  return (((uint16_t)(buffer[1] & 0x07)) << 8) | buffer[2];
 }

--- a/Adafruit_MCP3008.h
+++ b/Adafruit_MCP3008.h
@@ -19,15 +19,15 @@
 #ifndef Adafruit_MCP3008_h
 #define Adafruit_MCP3008_h
 
-#include <Arduino.h>
 #include <Adafruit_SPIDevice.h>
+#include <Arduino.h>
 
-#define MCP3008_SPI_MAX_5V 3600000         ///< SPI MAX Value on 5V pin
-#define MCP3008_SPI_MAX_3V 1350000         ///< SPI MAX Value on 3V pin
-#define MCP3008_SPI_MAX MCP3008_SPI_MAX_3V ///< SPI MAX Value
-#define MCP3008_SPI_ORDER SPI_BITORDER_MSBFIRST         ///< SPI bit order
-#define MCP3008_SPI_MODE SPI_MODE0         ///< SPI mode
-#define MCP3008_SPI_FREQ 1000000           ///< SPI clock speed
+#define MCP3008_SPI_MAX_5V 3600000              ///< SPI MAX Value on 5V pin
+#define MCP3008_SPI_MAX_3V 1350000              ///< SPI MAX Value on 3V pin
+#define MCP3008_SPI_MAX MCP3008_SPI_MAX_3V      ///< SPI MAX Value
+#define MCP3008_SPI_ORDER SPI_BITORDER_MSBFIRST ///< SPI bit order
+#define MCP3008_SPI_MODE SPI_MODE0              ///< SPI mode
+#define MCP3008_SPI_FREQ 1000000                ///< SPI clock speed
 
 /*!
  *  @brief  Class that stores state and functions for interacting with

--- a/Adafruit_MCP3008.h
+++ b/Adafruit_MCP3008.h
@@ -20,13 +20,14 @@
 #define Adafruit_MCP3008_h
 
 #include <Arduino.h>
-#include <SPI.h>
+#include <Adafruit_SPIDevice.h>
 
 #define MCP3008_SPI_MAX_5V 3600000         ///< SPI MAX Value on 5V pin
 #define MCP3008_SPI_MAX_3V 1350000         ///< SPI MAX Value on 3V pin
 #define MCP3008_SPI_MAX MCP3008_SPI_MAX_3V ///< SPI MAX Value
-#define MCP3008_SPI_ORDER MSBFIRST         ///<  SPI ORDER
-#define MCP3008_SPI_MODE SPI_MODE0         ///< SPI MODE
+#define MCP3008_SPI_ORDER SPI_BITORDER_MSBFIRST         ///< SPI bit order
+#define MCP3008_SPI_MODE SPI_MODE0         ///< SPI mode
+#define MCP3008_SPI_FREQ 1000000           ///< SPI clock speed
 
 /*!
  *  @brief  Class that stores state and functions for interacting with
@@ -40,13 +41,10 @@ public:
   int readADCDifference(uint8_t differential);
 
 private:
-  uint8_t cs;
-  uint8_t mosi;
-  uint8_t miso;
-  uint8_t sck;
-  bool hwSPI;
+  Adafruit_SPIDevice *spi_dev = NULL; ///< Pointer to SPI bus interface
+  uint8_t _cs;
+  uint8_t buffer[3];
   int SPIxADC(uint8_t channel, bool differential);
-  SPIClass *_spi;
 };
 
 #endif

--- a/library.properties
+++ b/library.properties
@@ -1,9 +1,10 @@
 name=Adafruit MCP3008
-version=1.2.0
+version=1.3.0
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=MCP3008 8-Channel 10-Bit ADC
-paragraph=MCP3008 8-Channel 10-Bit ADC 
+paragraph=MCP3008 8-Channel 10-Bit ADC
 category=Signal Input/Output
 url=https://github.com/adafruit/Adafruit_MCP3008
 architectures=*
+depends=Adafruit BusIO


### PR DESCRIPTION
For #6. Converts to BusIO usage.

Tested with Feather ESP32. Moving a wire connected to VCC down each pin in order, others floating:
![Screenshot from 2021-06-24 10-45-45](https://user-images.githubusercontent.com/8755041/123309102-5987dd00-d4d9-11eb-8293-b50c9260f113.png)