### PR TITLE
Tweak memory alloc and cleanup

### DIFF
--- a/Adafruit_MCP3008.cpp
+++ b/Adafruit_MCP3008.cpp
@@ -27,6 +27,11 @@
 
 #include <SPI.h>
 
+Adafruit_MCP3008::~Adafruit_MCP3008() {
+  if (spi_dev)
+    delete spi_dev;
+}
+
 // Initialize for hardware SPI
 
 /*!
@@ -39,6 +44,8 @@
  */
 bool Adafruit_MCP3008::begin(uint8_t cs, SPIClass *theSPI) {
   _cs = cs;
+  if (spi_dev)
+    delete spi_dev;
   spi_dev = new Adafruit_SPIDevice(cs, MCP3008_SPI_FREQ, MCP3008_SPI_ORDER,
                                    MCP3008_SPI_MODE, theSPI);
   return spi_dev->begin();

--- a/Adafruit_MCP3008.h
+++ b/Adafruit_MCP3008.h
@@ -35,6 +35,7 @@
  */
 class Adafruit_MCP3008 {
 public:
+  ~Adafruit_MCP3008();
   bool begin(uint8_t cs = SS, SPIClass *theSPI = &SPI);
   bool begin(uint8_t sck, uint8_t mosi, uint8_t miso, uint8_t cs);
   int readADC(uint8_t channel);

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit MCP3008
-version=1.3.0
+version=1.3.1
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=MCP3008 8-Channel 10-Bit ADC


### PR DESCRIPTION
Tested on Qt PY. Trim pot on CH0, all others noise.

```cpp
/***************************************************
Simple example of reading the MCP3008 analog input channels and printing
them all out.

Author: Carter Nelson
License: Public Domain
****************************************************/

#include <Adafruit_MCP3008.h>

Adafruit_MCP3008 adc;

int count = 0;

void setup() {
  Serial.begin(9600);
  while (!Serial);

  Serial.println("MCP3008 multi begin() test.");
}

void loop() {
  adc.begin(A0);

  for (int chan=0; chan<8; chan++) {
    Serial.print(adc.readADC(chan)); Serial.print("\t");
  }

  Serial.print("["); Serial.print(count); Serial.println("]");
  count++;
  
  delay(1000);
}
```

![Screenshot from 2021-08-24 11-39-40](https://user-images.githubusercontent.com/8755041/130672671-04129490-f7b3-4732-8e27-73cb485db49d.png)
